### PR TITLE
Re-add mailman script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,18 @@ You need [Ruby 2.0.0](https://www.ruby-lang.org), [Postgres](http://www.postgres
 
 ### Experimental IMAP Support
 
-Helpful has an experimental script for fetching email from an IMAP. To use this functionality you will need to .env and enter the details for the following environment variables:
+Helpful has an experimental script for fetching email from an IMAP mailbox. To use this functionality you will need to edit .env and enter the details for the following environment variables:
 
     MAILMAN_IMAP_SERVER
     MAILMAN_IMAP_PORT
     MAILMAN_IMAP_USERNAME
     MAILMAN_IMAP_PASSWORD
-    MAILMAN_IMAP_FOLDER
+    MAILMAN_IMAP_FOLDER (optional, default: Helpful-Test)
+    MAILMAN_IMAP_POLL (optional, default: 30 sec)
 
-To run this script
+To run this script:
 
-    $ bin/mailman
+    $ foreman run bin/mailman_worker
 
 ### Configuring Search (Elastic Search)
 

--- a/bin/mailman_worker
+++ b/bin/mailman_worker
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+require 'bundler/setup'
+require 'mailman'
+
+Mailman.config.imap = {
+  server: ENV['MAILMAN_IMAP_SERVER'],
+  port: ENV['MAILMAN_IMAP_PORT'] || 993,  # usually 995, 993 for gmail
+  ssl: true,
+  username: ENV['MAILMAN_IMAP_USERNAME'],
+  password: ENV['MAILMAN_IMAP_PASSWORD'],
+  folder: ENV['MAILMAN_IMAP_FOLDER'] || 'Helpful-Test'
+}
+
+Mailman.config.poll_interval = (ENV['MAILMAN_IMAP_POLL'] || 30).to_i
+Mailman.config.ignore_stdin = true
+
+Mailman::Application.run do
+  default do
+    Messages::Email.receive(message)
+  end
+end
+


### PR DESCRIPTION
This PR re-adds the mailman script (now called mailman_worker) which was removed accidentally (it appears) in f9f50610896473273a6a6a400627b91cfbcc583f. Also updates README to reflect the use of `foreman run` to execute the script so that .env is parsed.

There is no WIP for this PR.
