### PR TITLE
Rename web_hook_url to webhook_url for consistency

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -13,7 +13,7 @@ class Message < ActiveRecord::Base
   attr_accessor :from
   belongs_to :person
 
-  after_create  :send_webhook, unless: Proc.new { |m| m.conversation.account.web_hook_url.nil? }
+  after_create  :send_webhook, unless: Proc.new { |m| m.conversation.account.webhook_url.nil? }
 
   def webhook_data
     { message: {

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -19,7 +19,7 @@ class Webhook < ActiveRecord::Base
       headers: {'X-Helpful-Webhook-Signature' => signature}
     }
 
-    response = HTTParty.post(account.web_hook_url, options)
+    response = HTTParty.post(account.webhook_url, options)
 
     self.update_attributes(
       response_code: response.code,

--- a/db/migrate/20131119205940_rename_web_hook_url_to_webhook_url.rb
+++ b/db/migrate/20131119205940_rename_web_hook_url_to_webhook_url.rb
@@ -1,0 +1,5 @@
+class RenameWebHookUrlToWebhookUrl < ActiveRecord::Migration
+  def change
+    rename_column :accounts, :web_hook_url, :webhook_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,12 +18,12 @@ ActiveRecord::Schema.define(version: 20131119225136) do
   enable_extension "hstore"
 
   create_table "accounts", id: false, force: true do |t|
-    t.uuid     "id",           null: false
+    t.uuid     "id",             null: false
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "slug",         null: false
-    t.string   "web_hook_url"
+    t.string   "slug",           null: false
+    t.string   "webhook_url"
     t.string   "webhook_secret"
   end
 

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -19,7 +19,7 @@ describe Account do
     end
   end
   
-  it "must have a web_hook_url field" do
-    assert Account.column_names.include?("web_hook_url")
+  it "must have a webhook_url field" do
+    assert Account.column_names.include?("webhook_url")
   end
 end

--- a/test/models/webhook_test.rb
+++ b/test/models/webhook_test.rb
@@ -18,7 +18,7 @@ describe Webhook do
       @webhook = FactoryGirl.create(:webhook)
 
       @webhook.account.webhook_secret = 'abc123'
-      @webhook.account.web_hook_url   = 'http://example.com'
+      @webhook.account.webhook_url   = 'http://example.com'
 
       @webhook.body = %{{"id":"634d1cad-94e9-471c-b6dc-95ce18140b89","account_id":"f7dfb266-f88c-4219-9cc6-d4f0e9881de9","created_at":"2013-11-19T16:55:12Z","event":"helpful.test.test","data":{"foo":"bar"}}}
       @expected_signature = '5d2fe8ded5c7bfc33822d9a4d7148629e73ad7a1f8bcb4cd0e34da1b914e0654'


### PR DESCRIPTION
This PR standardizes the spelling of webhook across the codebase by changing the web_hook_url attribute on Account to webhook_url.

There is no WIP for this PR.
