### PR TITLE
Added API docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'sass-rails', '~> 4.0.0'
 gem 'sequential', '>= 0.1'
 gem 'sidekiq'
 gem 'uglifier', '>= 1.3.0'
+gem 'redcarpet'
 
 group :development do
   gem 'rest-client', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.1.0)
+    redcarpet (3.0.0)
     redis (3.0.6)
     redis-namespace (1.3.2)
       redis (~> 3.0.4)
@@ -221,6 +222,7 @@ DEPENDENCIES
   rails (= 4.0.2)
   rails_12factor
   rake
+  redcarpet
   rest-client
   sass-rails (~> 4.0.0)
   sequential (>= 0.1)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,4 +8,11 @@ class PagesController < ApplicationController
     redirect_to ActionController::Base.helpers.javascript_path('embed.js')
   end
 
+  def docs
+    renderer = Redcarpet::Render::HTML.new#, :no_links => true, :hard_wrap => true
+    markdown = Redcarpet::Markdown.new renderer#, :autolink => true, :space_after_headers => true
+    text = markdown.render(File.read(Rails.root.join('app','views','pages','docs.md'))).html_safe
+    render inline: text, layout: true
+  end
+
 end

--- a/app/views/pages/docs.html.erb
+++ b/app/views/pages/docs.html.erb
@@ -1,2 +1,0 @@
-<h1>Helfpul API Documentation</h1>
-<p>Work in progress</p>

--- a/app/views/pages/docs.md
+++ b/app/views/pages/docs.md
@@ -1,0 +1,118 @@
+FORMAT: 1A
+
+# Helpful API
+Helpful API is a service to interact with helpful.io  It provides API access to all the resources in the app.
+
+# Helpful API Root [/api]
+NOT IMPLEMENTED - BUT LEFT FOR FUTURE REFERENCE Helpful API entry point.
+
+This resource does not have any attributes. Instead it offers the initial API affordances in the form of the HTTP Link header and HAL links.
+
+## Retrieve Entry Point [GET]
+
++ Response 200 (application/json)
+    + Headers
+
+            Link: <https://helpful.io/api/>;rel="self",<https://helpful.io/api/messages>;rel="conversations"
+
+    + Body
+
+            {
+                "_links": {
+                    "self": { "href": "/" },
+                    "messages": { "href": "/messages?{since}", "templated": true }
+                }
+            }
+
+
+# Group Messages
+Messages related resources of *Helpful API*.
+
+## Message [/message/{id}]
+A single Message object. The Message resource represents a single message that is part of a conversation.
+
+The Message resource has the following attributes:
+
+- id
+- conversation_id
+- person_id
+- data
+- created_at
+- updated_at
+- description
+- content
+
+The states *id* and *created_at* are assigned by the Helpful API at the moment of creation.
+
+
++ Parameters
+    + id (UUID) ... ID of the Message
+
++ Model (application/hal+json)
+
+    JSON representation of Message Resource. In addition to representing its state in the JSON form it offers affordances in the form of the HTTP Link header and HAL links.
+
+    + Headers
+
+    + Body
+
+            {
+                "id":"d06a5c13-0981-435d-9510-67e05277191b",
+                "conversation_id":"b9df99ba-ce31-4cc1-827d-a8c900a879ee",
+                "person_id":"81b303ca-258e-453c-bc84-5eafba8cef87",
+                "content":"Voluptatem ab. Ipsum quo.",
+                "data":null,
+                "created_at":"2013-12-08T13:08:14.758Z",
+                "updated_at":"2013-12-08T13:08:14.758Z"
+            }
+
+### Retrieve a Single Message [GET]
++ Response 200
+
+    [Message][]
+
+
+## Messages Collection [/messages{?since}]
+Collection of all Messages.
+
+The Message Collection resource has the following attribute:
+
+- total
+
+In addition it **embeds** *Message Resources* in the Helpful API.
+
+
++ Model (application/json)
+
+    JSON representation of Message Collection Resource. The Message resources in collections are embedded. Note the embedded Messages resource are incomplete representations of the Message in question. Use the respective Message link to retrieve its full representation.
+
+    + Headers
+
+            Link: <https://helpful.io/api/messages>;rel="self"
+
+    + Body
+
+            {
+                "messages": [
+                    {
+                        "id":"d06a5c13-0981-435d-9510-67e05277191b",
+                        "conversation_id":"b9df99ba-ce31-4cc1-827d-a8c900a879ee",
+                        "person_id":"81b303ca-258e-453c-bc84-5eafba8cef87",
+                        "content":"Voluptatem ab. Ipsum quo.",
+                        "data":null,
+                        "created_at":"2013-12-08T13:08:14.758Z",
+                        "updated_at":"2013-12-08T13:08:14.758Z"
+                    }
+                ]
+            }
+
+### List All Messages [GET]
++ Parameters
+    + since (optional, string) ... Timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ` Only Messages updated at or after this time are returned.
+
++ Response 200
+
+    [Messages Collection][]
+
+### Create a Message [POST]
+TODO


### PR DESCRIPTION
This starts an outline of the API docs.

The formatting is Markdown as described by the latest Apiary Blueprint
format:  http://apiary.io/blueprint

This format allows for:
- Easy to type/format
- Machine readable/parsable docs
- Viewable on Apiary.io

For local viewing, kept the ability to just look at it via /docs.  But
Apiary.io is much nicer and gives a UI for easy testing.
