### PR TITLE
WIP 178 Fix Devise Email From Address

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,11 @@ PORT=5000
 # This is the route to get to the ElasticSearch server
 ELASTICSEARCH_URL=http://127.0.0.1:9200
 
-# The domain that inbound email addresses should use
-INCOMING_EMAIL_DOMAIN=helpful.io
+# The domain that inbound email addresses should use (default: helpful.io)
+#INCOMING_EMAIL_DOMAIN=helpful.io
+
+# The domain that outgoing email should come from (default: helpful.io)
+#OUTGOING_EMAIL_DOMAIN=helpful.io
 
 # Your Mailgun API Key (starts with "key-")
 MAILGUN_API_KEY=your_mailgun_api_key_here

--- a/config/initializers/01_env.rb
+++ b/config/initializers/01_env.rb
@@ -5,4 +5,7 @@ module Helpful
     ENV['INCOMING_EMAIL_DOMAIN'] || 'helpful.io'
   end
 
+  def outgoing_email_domain
+    ENV['OUTGOING_EMAIL_DOMAIN'] || 'helpful.io'
+  end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -19,7 +19,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = "Helpful <noreply@#{Helpful.outgoing_email_domain}>"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
WIP: https://assemblymade.com/helpful/wips/178

This PR changes the email address in the devise initializer to "Helpful noreply@OUTGOING_EMAIL_DOMAIN" where OUTGOING_EMAIL_DOMAIN defaults to "helpful.io" but can be overridden in .env.

It also makes INCOMING_EMAIL_DOMAIN in .env optional (commented out) since it serves as an override for the default (set in config/initializers/01_env.rb).

Lastly, it forces the env.rb initializer to be loaded first by renaming it to 01_env.rb, this ensures that all values exposed by env.rb are available in later initializers. 
