### PR TITLE
WIP 165 Ensure we filter display name out of email before saving

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -17,4 +17,15 @@ class Person < ActiveRecord::Base
     allow_blank: true,
     uniqueness: {:scope => :account}
 
+  before_save :parse_email
+
+  private
+
+  # Private: Make sure we only save the address portion of an email address.
+  #
+  # Returns nothing.
+  def parse_email
+    mail = Mail::Address.new(self.email)
+    self.email = mail.address
+  end
 end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -8,4 +8,22 @@ describe Person do
   it "must be valid" do
     @person.valid?.must_equal true
   end
+
+  describe "Person#parse_email" do
+
+    it "handles email addresses without display names" do
+      email = "jsmith@example.com"
+      @person.email = email
+      @person.save
+
+      assert_equal email, @person.email
+    end
+
+    it "parses out the email address from email" do
+      @person.email = "John Smith <jsmith@example.com>"
+      @person.save
+
+      assert_equal "jsmith@example.com", @person.email
+    end
+  end
 end


### PR DESCRIPTION
WIP: https://assemblymade.com/helpful/wips/165

This PR adds a before_save hook to Person which ensures that only the address portion of an email is persisted to the email field. It filters out all other parts of the address.

The correct way to extract the display name from an email address and save it to the person is implemented in the Api::MessagesController (https://github.com/asm-helpful/helpful-web/blob/master/app/controllers/api/messages_controller.rb#L26)
