### PR TITLE
Always load env vars with `dotenv-rails`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ end
 group :development, :test do
   gem 'rake'
   gem 'ffaker', '~> 1.20'
+  gem 'dotenv-rails'
 end
 
 group :development, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,9 @@ GEM
     doorkeeper (0.7.4)
       jquery-rails (>= 2.0.2)
       railties (>= 3.1)
+    dotenv (0.9.0)
+    dotenv-rails (0.9.0)
+      dotenv (= 0.9.0)
     elasticsearch (0.4.1)
       elasticsearch-api (= 0.4.1)
       elasticsearch-transport (= 0.4.1)
@@ -221,6 +224,7 @@ DEPENDENCIES
   curb
   devise (~> 3.1)
   doorkeeper
+  dotenv-rails
   elasticsearch (~> 0.4.1)
   factory_girl_rails (~> 4.2.1)
   ffaker (~> 1.20)


### PR DESCRIPTION
The tests still pass when run with `foreman`, but trying to load the rails environment alone without the env vars fails.

Requiring `dotenv-rails` should just load up the `.env` file whenever the rails environment is loaded. `rails console` and normal `rake` tasks should work now.
