### PR TITLE
Upgrading vagrant box to ruby 2.1 and updating postgres for WIP #195

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = 'heroku'
-  config.vm.box_url = 'https://dl.dropboxusercontent.com/s/auq7ipsbwgzmp9a/heroku.box'
+  config.vm.box_url = 'https://www.dropbox.com/s/tvxwobc83q4hlf5/heroku.box'
   config.vm.provision :shell, path: 'config/vagrant/bootstrap.sh'
 
   # Create a forwarded port mapping which allows access to a specific port

--- a/config/vagrant/bootstrap.sh
+++ b/config/vagrant/bootstrap.sh
@@ -8,6 +8,23 @@ log "Updating Aptitude and Installing the Basics"
 apt-get update
 apt-get install curl python-software-properties -y
 
+log "Installing Reqs for UUID"
+add-apt-repository ppa:pitti/postgresql
+apt-get update
+apt-get install postgresql-contrib-9.2 -y
+
+# For whatever reason the files exist in /9.2/extensions but not /extensions. Copying them seems to work.
+sudo cp /usr/share/postgresql/9.2/extension/* /usr/share/postgresql/extension/
+
+# extensions/uuid-ossp.control points to $libdir/uuid-ossp which doesn't appear to exist, so we update it with another file locaiton that does exist.
+sed 's:$libdir/uuid-ossp:/usr/lib/postgresql/9.2/lib/uuid-ossp.so:' < /usr/share/postgresql/extension/uuid-ossp.control > uuid-ossp.control
+sudo mv uuid-ossp.control /usr/share/postgresql/extension/uuid-ossp.control
+
+# Restart postgresql
+sudo /etc/init.d/postgresql restart
+
+
+
 log "Installing and Starting Redis"
 /usr/bin/add-apt-repository ppa:chris-lea/redis-server
 apt-get update


### PR DESCRIPTION
This is almost definitely not the best way to fix the postgres uuid bug, so I would love any feedback on making this better. 

In the meantime - this appears to work and should allow new devs to jump onto helpful with just 'vagrant up'.
