### PR TITLE
Fixed homepage email link to include mailto

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -81,7 +81,7 @@
       <br/>
 
       <p>
-        <strong>Enterprise</strong>. More conversations? Firewall? Whitelabeling? <a href="helpful@helpful.io">Please contact us</a>.
+        <strong>Enterprise</strong>. More conversations? Firewall? Whitelabeling? <a href="mailto:helpful@helpful.io">Please contact us</a>.
       </p>
 
 


### PR DESCRIPTION
"Please contact us" links to helpful.io/helpful@helpful.io, added the missing mailto. 
