### PR TITLE
WIP 239 Conversation Notifications

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -32,6 +32,14 @@ class Conversation < ActiveRecord::Base
   scope :archived, -> { where(status: STATUS_ARCHIVED) }
   scope :most_stale, -> { joins(:messages).order('messages.updated_at ASC') }
 
+  def mailing_list
+    if assigned?
+      participants + [agent.person]
+    else
+      participants + account.people
+    end
+  end
+
   def ordered_messages
     messages.order(:created_at => :asc)
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -63,7 +63,7 @@ class Message < ActiveRecord::Base
   end
 
   def mail_recipients
-    conversation.participants - [person]
+    conversation.mailing_list - [person]
   end
 
   # Public: Create a read receipt for this message.

--- a/app/views/message_mailer/created.text.erb
+++ b/app/views/message_mailer/created.text.erb
@@ -1,6 +1,3 @@
-A new message was added to your support request:
-===============================================
-
 <%= word_wrap(@message.content).gsub(/\n/, "\n>") %>
 Posted <%= time_ago_in_words(@message.created_at) %> ago by <%= nickname(@message.person) %>
 
@@ -10,3 +7,6 @@ Conversation history
   <%= word_wrap(message.content).gsub(/\n/, "\n>") %>
   Posted <%= time_ago_in_words(message.created_at) %> ago by <%= nickname(message.person) %>
 <% end %>
+
+--
+Reply to this email to continue the conversation.

--- a/test/factories/accounts.rb
+++ b/test/factories/accounts.rb
@@ -3,5 +3,15 @@
 FactoryGirl.define do
   factory :account do
     name { Faker::Company.name }
+
+    factory :account_with_users do
+      ignore do
+        user_count 2
+      end
+
+      after(:create) do |account, evaluator|
+        FactoryGirl.create_list(:membership, evaluator.user_count, account: account)
+      end
+    end
   end
 end

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -146,4 +146,20 @@ describe Conversation do
       refute @conversation.assigned?
     end
   end
+
+  describe "#mailing_list" do
+    it "includes the agent if assigned" do
+      user = FactoryGirl.create(:user)
+      @conversation.agent = user
+      assert @conversation.mailing_list.include?(user.person)
+    end
+
+    it "includes the team if not assigned" do
+      @conversation.agent = nil
+      account = FactoryGirl.create(:account_with_users)
+      account.people.each do |person|
+        assert @conversation.mailing_list.include? person
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR effectively adds New Conversation Notifications by enhancing the existing message notification system.

Conversation#mailing_list is added to return the list of people to send emails to regarding that Conversation. This list contains the participants (people who have actually authored messages) and if assigned the agent. If unassigned the entire team (Account.people) are added.

So when a new message comes in the email notification list is now based on assigned status:
- ASSIGNED: conversation.participants + conversation.agent - message.person (the author of the new message)
- UN-ASSIGNED: conversation.participants + conversation.account.people - message.person (the author of the new message)

WIP: https://assemblymade.com/helpful/wips/239
