### PR TITLE
Made "Muted" label readable

### DIFF
--- a/app/views/pages/styleguide.html.erb
+++ b/app/views/pages/styleguide.html.erb
@@ -100,7 +100,7 @@
           <li class="bg-success text-white">Success</li>
           <li class="bg-warning text-white">Warning</li>
           <li class="bg-danger text-white">Danger</li>
-          <li class="bg-muted">Muted</li>
+          <li class="bg-muted text-white">Muted</li>
         </ul>
       </div>
 


### PR DESCRIPTION
It's currently the same color as its background, making it unreadable.

![](https://dl.dropboxusercontent.com/s/qtjxi7qc8hmf4ew/Screenshot%202014-01-28%2018.47.38.png)
