### PR TITLE
Removes bullet points appearing next to two colors #248

### DIFF
--- a/app/views/pages/styleguide.html.erb
+++ b/app/views/pages/styleguide.html.erb
@@ -93,7 +93,7 @@
       <p>If you need a tinted version (like for drop shadows, see buttons section), use SCSS <code>darken($color, <strong>15%</strong>)</code>.</p>
 
       <div class="example">
-        <ul class="color-swatch">
+        <ul class="color-swatch" style="list-style: none;">
           <li class="bg-white text-black">White</li>
           <li class="bg-black text-white">Black</li>
           <li class="bg-primary text-white">Primary</li>


### PR DESCRIPTION
Quick and dirty, but does the job. Image:

![](https://dl.dropboxusercontent.com/s/qtjxi7qc8hmf4ew/Screenshot%202014-01-28%2018.47.38.png)
