### PR TITLE
Set the display name for MessageMailer to @message.person.name

### DIFF
--- a/app/mailers/message_mailer.rb
+++ b/app/mailers/message_mailer.rb
@@ -16,9 +16,16 @@ class MessageMailer < ActionMailer::Base
 
     subject = summary(@conversation)
 
+    from = @message.account.mailbox
+    reply_to = @conversation.mailbox
+    # Override the default display name with the name of the person who sent
+    # the message.
+    from.display_name = @message.person.name
+    reply_to.display_name = @message.person.name
+
     mail to: @recipient.email,
-         from: @message.account.mailbox,
-         reply_to: @conversation.mailbox,
+         from: from,
+         reply_to: reply_to,
          subject: "[#{@message.account.slug}] #{subject}"
   end
 end

--- a/test/mailers/message_mailer_test.rb
+++ b/test/mailers/message_mailer_test.rb
@@ -25,8 +25,8 @@ describe MessageMailer, :created do
 
   it "has the correct reply_to display_name" do
     email = MessageMailer.created(@message.id, @recipient.id)
-    assert_equal @message.conversation.mailbox.to_s,
-      email[:reply_to].addrs.first.to_s
+    assert_equal @message.person.name,
+      email[:reply_to].addrs.first.display_name.to_s
   end
 
   it "has the correct from address" do
@@ -36,6 +36,7 @@ describe MessageMailer, :created do
 
   it "has the correct from display_name" do
     email = MessageMailer.created(@message.id, @recipient.id)
-    assert_equal @message.account.mailbox.to_s, email[:from].addrs.first.to_s
+    assert_equal @message.person.name,
+      email[:from].addrs.first.display_name.to_s
   end
 end


### PR DESCRIPTION
WIP: https://assemblymade.com/helpful/wips/254

This WIP/PR sets the display name used by MessageMailer to the name of the person who triggered the notification email. See the WIP for more details.
