### PR TITLE
Fix small typo and add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@ Help shouldn't hurt.
 
 [![Build Status](https://travis-ci.org/asm-helpful/helpful-web.png?branch=master)](https://travis-ci.org/asm-helpful/helpful-web)
 [![Code Climate](https://codeclimate.com/github/support-foo/web.png)](https://codeclimate.com/github/support-foo/web)
+[![Inline docs](http://inch-pages.github.io/github/asm-helpful/helpful-web.png)](http://inch-pages.github.io/github/asm-helpful/helpful-web)
 
 Helpful is an open product that's being built by a fantastic group of people on [Assembly](https://assemblymade.com/helpful). Anybody can join in building this product and earn a stake of the profit.
 
 
 ## Getting Started
 
-[Vagrant](http://vagrantup.com) is the reccomended way to run Helpful on your own machine. You need to download and install [Vagrant](http://vagrantup.com/downloads) before you can continue (this will take a while to run so you may want to grab some coffee).
+[Vagrant](http://vagrantup.com) is the recommended way to run Helpful on your own machine. You need to download and install [Vagrant](http://vagrantup.com/downloads) before you can continue (this will take a while to run so you may want to grab some coffee).
 
     git clone https://github.com/asm-helpful/helpful-web.git helpful-web
     cd helpful-web


### PR DESCRIPTION
Hi there,

this patch fixes a small typo and adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/asm-helpful/helpful-web.png)](http://inch-pages.github.io/github/asm-helpful/helpful-web)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. Your status page is http://inch-pages.github.io/github/asm-helpful/helpful-web/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [Libnotify](https://github.com/splattael/libnotify).

What do you think?
