### PR TITLE
WIP#284: Potential bug: after_save pitfall

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -21,11 +21,12 @@ class Message < ActiveRecord::Base
                              allow_blank: false
                            }
 
-  after_commit :enqueue_to_update_search_index
   after_save :send_webhook, if: ->(message) {
     message.conversation.account.webhook_url?
   }
-  after_create :send_email
+
+  after_commit :enqueue_to_update_search_index, on: [:create, :update]
+  after_commit :send_email, on: :create
 
   scope :most_recent, -> { order('updated_at DESC') }
 

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -11,7 +11,7 @@ class Webhook < ActiveRecord::Base
   attr_accessor :data
 
   after_create :fill_in_body
-  after_create :enqueue_to_send, on: create
+  after_commit :enqueue_to_send, on: :create
 
   def dispatch!
     options = {

--- a/spec/support/test_after_commit.rb
+++ b/spec/support/test_after_commit.rb
@@ -1,0 +1,14 @@
+# This is to make sure that after_commit hooks are triggered in tests.
+require 'active_record/connection_adapters/abstract/transaction'
+module ActiveRecord
+  module ConnectionAdapters
+    class SavepointTransaction < OpenTransaction
+      def perform_commit_with_transactional_fixtures
+        commit_records if number == 1
+        perform_commit_without_transactional_fixtures        
+      end
+
+      alias_method_chain :perform_commit, :transactional_fixtures
+    end
+  end
+end


### PR DESCRIPTION
- Changed after_create & after_save to use after_commit. This is because in theory the data has not been persisted in an after_save or after_create.
- Removed puts statements I had from testing. Added in a test support file that makes sure that after_commit hooks are triggered in tests. Without it the tests that test that emails have been sent fail.
- Not 100% how this code worked before. But it did not look correct. Changed it to use after_commit on create instead of after_create on create.
