### PR TITLE
Fix query for finding the next conversation

### DIFF
--- a/app/models/conversations_inbox.rb
+++ b/app/models/conversations_inbox.rb
@@ -34,7 +34,7 @@ class ConversationsInbox
   #
   # Returns an Array of Conversation models.
   def conversations_queue
-    open_conversations.joins("LEFT OUTER JOIN respond_laters ON conversations.id = respond_laters.conversation_id AND respond_laters.user_id = '#{user.id}'").
+    @conversations_queue ||= open_conversations.joins("LEFT OUTER JOIN respond_laters ON conversations.id = respond_laters.conversation_id AND respond_laters.user_id = '#{user.id}'").
       order('respond_laters.updated_at ASC NULLS FIRST, conversations.updated_at DESC')
   end
 
@@ -44,7 +44,8 @@ class ConversationsInbox
   # Returns a Conversation model or nil if the argument is the last
   # conversation in the inbox
   def next_after(conversation)
-    conversations_queue.where('updated_at > ?', conversation.updated_at).first
+    index = conversations_queue.index { |c| c == conversation }
+    conversations_queue[index + 1]
   end
 
   # Public: Finds all the open conversations associated with the account.

--- a/spec/controllers/conversations_controller_spec.rb
+++ b/spec/controllers/conversations_controller_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe ConversationsController do
   let!(:account) { create(:account) }
-  let!(:conversation) { create(:conversation, account: account) }
+  let!(:next_conversation) { create(:conversation_with_messages, account: account) }
+  let!(:conversation) { create(:conversation_with_messages, account: account) }
   let!(:user) { create(:user_with_account, account: account) }
 
   before { sign_in(user) }
@@ -56,5 +57,16 @@ describe ConversationsController do
     conversation.reload
 
     expect(conversation.respond_laters).not_to be_empty
+  end
+
+  it 'shows a conversation' do
+    get :show,
+      {
+        account_id: account.slug,
+        id: conversation.number
+      }
+
+    expect(assigns(:conversation)).to eq(conversation)
+    expect(assigns(:next_conversation)).to eq(next_conversation)
   end
 end


### PR DESCRIPTION
Whoops. The next conversation query was broken. Added a test to make sure everything is finally working. My bad.
