### PR TITLE
Don't create orphaned person records when updating

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,10 @@ class User < ActiveRecord::Base
 
   has_many :oauth_applications, class_name: 'Doorkeeper::Application', as: :owner
 
+  delegate :name,
+    to: :person,
+    allow_nil: true
+
   accepts_nested_attributes_for :person
 
   # Returns the first owned account

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -11,24 +11,20 @@
     <h1>User Settings</h1>
   </div>
 
-  <%= form_for current_user, html: {class: 'form'} do |form| %>
+  <%= form_for current_user, html: {class: 'form'} do |f| %>
 
-    <%= form.fields_for :person do |person_form| %>
+    <div class="form-group">
+      <%= f.label :name, 'Name', class: 'form-label' %>
+      <%= f.text_field :name, class: 'form-control' %>
+    </div>
 
-      <div class="form-group">
-        <%= person_form.label :name, 'Name', class: 'form-label' %>
-        <%= person_form.text_field :name, class: 'form-control' %>
-      </div>
-
-      <div class="form-group">
-        <%= person_form.label :email, 'Email', class: 'form-label' %>
-        <%= person_form.text_field :email, class: 'form-control' %>
-      </div>
-
-    <% end %>
+    <div class="form-group">
+      <%= f.label :email, 'Email', class: 'form-label' %>
+      <%= f.text_field :email, class: 'form-control' %>
+    </div>
 
     <div class="form-actions">
-      <%= form.submit 'Update my personal settings', class: %W(btn btn-primary), rel: 'submit' %>
+      <%= f.submit 'Update my personal settings', class: %W(btn btn-primary), rel: 'submit' %>
     </div>
 
   <% end %>


### PR DESCRIPTION
Since we were incorrectly altering the records with `accepts_nested_attributes`, updating both separately in a transaction seems to make more sense.

It also cleans up the form since we can just use flat user attributes.
