### PR TITLE
Add archived parameter to /api/conversations, #362

### DIFF
--- a/app/controllers/api/conversations_controller.rb
+++ b/app/controllers/api/conversations_controller.rb
@@ -2,7 +2,17 @@ class Api::ConversationsController < ApiController
 
   def index
     find_account!
-    @conversations = @account.conversations
+
+    if params[:archived]
+      if params[:archived] == "true"
+        @conversations = @account.conversations.archived
+      else
+        @conversations = @account.conversations.unresolved
+      end
+    else
+      @conversations = @account.conversations
+    end
+
     respond_with(@conversations)
   end
 


### PR DESCRIPTION
Adds a parameter to /api/conversations, ?archived=true gives only archived messages, ?archived=false gives only unresolved messages, no parameter gives all messages.

Task #362: https://assemblymade.com/helpful/wips/362
