### PR TITLE
Fix wrong display of inbox zero, task #371

### DIFF
--- a/app/assets/javascripts/conversations.js
+++ b/app/assets/javascripts/conversations.js
@@ -30,7 +30,7 @@ var conversations = {
   }
 }
 
-$(document).on("ready page:change", function(){
+$(document).on("ready", function(){
   $('.list').delegate('.respond-later', 'click', conversations.onRespondLaterClick);
   $('.list').delegate('.archive', 'click', conversations.onArchiveClick);
 });


### PR DESCRIPTION
This was caused by events handlers being registered double on the archive button. It already uses a delegate on list, which always stays on the page, so the handler doesn't need to be registered when the page changes.
