### PR TITLE
Fix migrations #493

### DIFF
--- a/db/migrate/20140222053020_change_conversation_archived_to_boolean.rb
+++ b/db/migrate/20140222053020_change_conversation_archived_to_boolean.rb
@@ -1,7 +1,7 @@
 class ChangeConversationArchivedToBoolean < ActiveRecord::Migration
   def up
     add_column :conversations, :archived, :boolean, default: false
-    Conversation.where(
+    Conversation.unscoped.where(
       status: 'archived'
     ).update_all(
       archived: true
@@ -11,7 +11,7 @@ class ChangeConversationArchivedToBoolean < ActiveRecord::Migration
 
   def down
     add_column :conversations, :status, :string
-    Conversation.where(
+    Conversation.unscoped.where(
       archived: true
     ).update_all(
       status: 'archived'

--- a/db/migrate/20140423194736_add_indexes_to_speed_up_inbox_query.rb
+++ b/db/migrate/20140423194736_add_indexes_to_speed_up_inbox_query.rb
@@ -2,7 +2,6 @@ class AddIndexesToSpeedUpInboxQuery < ActiveRecord::Migration
   def change
     add_index :conversations, [:account_id, :archived]
 
-    add_index :messages, :conversation_id
     add_index :messages, :person_id
 
     add_index :respond_laters, [:conversation_id, :user_id, :updated_at], name: 'index_respond_later_inbox'


### PR DESCRIPTION
For the `ChangeConversationArchivedToBoolean` migration I just used the `unscoped` method to skip Conversation's default scope.

For the `AddIndexesToSpeedUpInboxQuery` I removed the line that add the index `conversation_id` to the messages table, since messages already have this index.
