### PR TITLE
No canned responses text color fixed #594

### DIFF
--- a/app/views/canned_responses/index.html.erb
+++ b/app/views/canned_responses/index.html.erb
@@ -22,6 +22,6 @@
       <% end %>
     </div>
   <% else %>
-    <p class="text-muted"><%= t('.none_created') %></p>
+    <p><%= t('.none_created') %></p>
   <% end %>
 </div>


### PR DESCRIPTION
Right now it's almost impossible to read the text:

![](https://d1015h9unskp4y.cloudfront.net/attachments/a243cae7-ae93-4477-8524-b9f16976fb90/canned.png)
