### PR TITLE
Added jazz_hands suite of tools and awesome_print

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'stripe'
 gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
 gem 'unf'
+gem 'awesome_print'
+gem 'pry-rails'
 
 group :development do
   gem 'quiet_assets'
@@ -53,6 +55,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'jazz_hands'
   gem 'factory_girl_rails', '~> 4.2.1'
   gem 'ffaker', '~> 1.20'
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,11 +43,14 @@ GEM
     addressable (2.3.5)
     analytics-ruby (1.0.0)
     arel (5.0.1.20140414130214)
+    awesome_print (1.2.0)
     aws-sdk (1.34.1)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
       uuidtools (~> 2.1)
     bcrypt-ruby (3.1.2)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bootstrap-sass (3.1.1.0)
       sass (~> 3.2)
     bourbon (3.1.8)
@@ -82,13 +85,22 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.7.0)
+    columnize (0.8.9)
     connection_pool (1.2.0)
+    coolline (0.4.3)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     css_parser (1.3.5)
       addressable
     curb (0.8.5)
     database_cleaner (1.2.0)
+    debug_inspector (0.0.2)
+    debugger (1.6.8)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.3.5)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.3.5)
     devise (3.2.2)
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.1)
@@ -100,6 +112,7 @@ GEM
       actionmailer (>= 3.2.6, < 5)
       devise (>= 3.2.0)
     diff-lcs (1.2.5)
+    diffy (3.0.4)
     docile (1.1.3)
     doorkeeper (1.0.0)
       railties (>= 3.1)
@@ -132,8 +145,13 @@ GEM
       railties (>= 3.2, < 5.0)
     friendly_id (5.0.3)
       activerecord (>= 4.0.0)
+    grit (2.5.0)
+      diff-lcs (~> 1.1)
+      mime-types (~> 1.15)
+      posix-spawn (~> 0.3.6)
     hashie (2.0.5)
     hike (1.2.3)
+    hirb (0.7.2)
     htmlentities (4.3.1)
     httparty (0.13.0)
       json (~> 1.8)
@@ -141,6 +159,18 @@ GEM
     httpclient (2.3.4.1)
     i18n (0.6.9)
     jasmine-core (2.0.0)
+    jazz_hands (0.5.2)
+      awesome_print (~> 1.2)
+      coolline (>= 0.4.2)
+      hirb (~> 0.7.1)
+      pry (~> 0.9.12)
+      pry-debugger (~> 0.2.2)
+      pry-doc (~> 0.4.6)
+      pry-git (~> 0.2.3)
+      pry-rails (~> 0.3.2)
+      pry-remote (>= 0.1.7)
+      pry-stack_explorer (~> 0.4.9)
+      railties (>= 3.0, < 5.0)
     jquery-rails (3.1.0)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
@@ -173,6 +203,7 @@ GEM
     pg (0.17.1)
     phantomjs (1.9.7.0)
     polyglot (0.3.4)
+    posix-spawn (0.3.8)
     premailer (1.8.0)
       css_parser (>= 1.3.5)
       htmlentities (>= 4.0.0)
@@ -183,6 +214,24 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
+    pry-debugger (0.2.2)
+      debugger (~> 1.3)
+      pry (~> 0.9.10)
+    pry-doc (0.4.6)
+      pry (>= 0.9)
+      yard (>= 0.8)
+    pry-git (0.2.3)
+      diffy
+      grit
+      pry (>= 0.9.8)
+    pry-rails (0.3.2)
+      pry (>= 0.9.10)
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
+    pry-stack_explorer (0.4.9.1)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     psych (2.0.5)
     puma (2.7.1)
       rack (>= 1.1, < 2.0)
@@ -318,6 +367,7 @@ GEM
       crack (>= 0.3.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    yard (0.8.7.4)
 
 PLATFORMS
   ruby
@@ -325,6 +375,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   analytics-ruby
+  awesome_print
   bootstrap-sass
   bourbon
   bugsnag
@@ -346,6 +397,7 @@ DEPENDENCIES
   font-awesome-rails
   friendly_id (~> 5.0)
   jasmine!
+  jazz_hands
   jquery-rails
   medium-editor-rails
   mini_magick
@@ -354,6 +406,7 @@ DEPENDENCIES
   pg
   premailer-rails
   pry
+  pry-rails
   psych (~> 2.0.5)
   puma
   pusher

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,5 +44,13 @@ module Helpful
     config.to_prepare do
       Devise::Mailer.layout "email"
     end
+
+    console do
+      config.console = Pry
+    end
+
+    config.after_initialize do
+      Hirb.enable if Rails.env.development? || Rails.env.test?
+    end
   end
 end


### PR DESCRIPTION
jazz_hands is a curated suite of tools for Rails. It adds Hirb, Awesome
Print, Pry and a bundle of Pry extensions that are super useful.

awesome_print is explicitly added into the production environment
because it provides a logging extesion that is incredibly useful for
reading hard-to-parse complex structures in logs.
`log.ap(Message.new, :debug)` for an example. Hirb is configured to be
automatically enabled in development and testing.

I also configure Pry as the default console shell for all environents
because it is just so darned powerful.
