### PR TITLE
#585 Improve signup errors

### DIFF
--- a/app/assets/stylesheets/_variables.css.scss
+++ b/app/assets/stylesheets/_variables.css.scss
@@ -51,6 +51,7 @@ $highlight  : #FEA;
 
 $secondary  : $success;
 $error      : $danger;
+$darker-gray: $alert-background;
 
 $text-color: $black;
 

--- a/app/assets/stylesheets/modules/panel.css.scss
+++ b/app/assets/stylesheets/modules/panel.css.scss
@@ -11,6 +11,7 @@ $panel-title: $light-black;
   @include box-shadow(0 1px 1px rgba(0,0,0,.05));
 
   blockquote {
+    color: $dark-gray;
     border-color: #ddd;
     border-color: rgba(0,0,0,.15);
   }
@@ -22,6 +23,31 @@ $panel-title: $light-black;
 
 .panel-error {
   border: 1px solid lighten($danger, 25%);
+
+  i.ss-alert {
+    display: inline-block;
+    padding-right: 5px;
+    font-size: 20px;
+    vertical-align: top;
+    color: $danger;
+  }
+
+  .panel-title {
+    display: inline-block;
+    font-weight: bold;
+    color: $darker-gray;
+  }
+
+  ul {
+    list-style: none;
+    color: $light-black;
+    line-height: 1.5;
+    padding-left: 0;
+  }
+}
+
+form fieldset .panel-error {
+  margin: 2em 0 1em 0;
 }
 
 .panel-title {

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,15 +1,18 @@
 <% if target.errors.any? %>
-  <div class="panel panel-errors">
+  <div class="panel panel-error error-message">
+    <i class="ss-alert"></i>
     <div class="panel-title">
       Oops! Something went wrong.
     </div>
 
     <div class="panel-body">
-      <% target.errors.full_messages.each do |message| %>
-        <p>
-          <%= message %>
-        </p>
-      <% end %>
+      <ul>
+        <% target.errors.full_messages.each do |message| %>
+          <li>
+            <%= message %>
+          </li>
+        <% end %>
+      </ul>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
I’ve made the experience for getting errors on signup much better. The panel is much more noticeable now, thanks to a bold header and alert symbol. The overall design has been cleaned up too.

Here’s what the original looks like:

![old-validation](https://cloud.githubusercontent.com/assets/5074763/3212635/7508a130-ef68-11e3-93f9-a4039b0edd69.png)

And here’s mine:

![new-validation](https://cloud.githubusercontent.com/assets/5074763/3212632/35640f56-ef68-11e3-85e2-adcdd227ba28.png)
