### PR TITLE
#622 Make command bar buttons responsive

### DIFF
--- a/app/assets/stylesheets/modules/command_bar_action.css.scss
+++ b/app/assets/stylesheets/modules/command_bar_action.css.scss
@@ -10,7 +10,7 @@
  
   button.btn-default {
     @media screen and (max-width: 1200px) {
-      margin-bottom: 12px
+      margin-bottom: 12px;
     }
   }
 }


### PR DESCRIPTION
@mdeiters noticed that the buttons are rather stuck together when you have a small window:

![Buttons not being responsive](https://d8izdk6bl4gbi.cloudfront.net/frame_0/https://d8izdk6bl4gbi.cloudfront.net/frame_0/https://d1015h9unskp4y.cloudfront.net/attachments/a8813f3e-8c59-4221-a83d-3217406841cd/Screen%20Shot%202014-05-29%20at%203.16.33%20PM.png)

So now they have some space between them!
