### PR TITLE
Refactor concierge

### DIFF
--- a/app/controllers/incoming_messages_controller.rb
+++ b/app/controllers/incoming_messages_controller.rb
@@ -6,7 +6,7 @@ class IncomingMessagesController < ApplicationController
     email = Mail::Address.new params.fetch(:email)
     author = MessageAuthor.new(account, email)
 
-    conversation = Concierge.new(account, params).find_conversation
+    conversation = Concierge.find_conversation(account, params)
     @message = author.compose_message(conversation, params.fetch(:content))
 
     content_type = 'application/json'

--- a/app/models/concierge.rb
+++ b/app/models/concierge.rb
@@ -1,12 +1,6 @@
 # Figures out which conversation an incoming message belongs to. If it can't
 # match it to a conversation it creates a new one.
-class Concierge
-  def initialize(account, params)
-    @account = account
-    @conversations = account.conversations
-    @params = params
-  end
-
+module Concierge
   # Public: Finds or creates a conversation based on the params hash. The order
   # of precedence is:
   #   - An explicit conversation number (params[:conversation]).
@@ -14,14 +8,15 @@ class Concierge
   # If no conversation has been found, create a new one.
   #
   # Returns a Conversation.
-  def find_conversation
+  def self.find_conversation(account, params)
+    conversations = account.conversations
     # If we have an explicit conversation number try that first
-    conversation = @conversations.where(number: @params[:conversation]).first
+    conversations.find_by(number: params[:conversation]) ||
 
     # If that didn't work, match on the recipient email address, looking for replies
-    conversation ||= Conversation.match_mailbox(@params[:recipient])
+    Conversation.match_mailbox(params[:recipient])  ||
 
     # If that didn't work, create a new conversation
-    conversation ||= @conversations.create(subject: @params[:subject])
+    conversations.create(subject: params[:subject])
   end
 end

--- a/app/models/welcome_conversation.rb
+++ b/app/models/welcome_conversation.rb
@@ -26,7 +26,7 @@ END
     email = Mail::Address.new(FROM)
     author = MessageAuthor.new(account, email)
 
-    conversation = Concierge.new(account, subject: SUBJECT).find_conversation
+    conversation = Concierge.find_conversation(account, subject: SUBJECT)
     author.compose_message(conversation, CONTENT).save
 
     conversation

--- a/spec/models/concierge_spec.rb
+++ b/spec/models/concierge_spec.rb
@@ -11,13 +11,13 @@ describe Concierge do
     it "should find a conversation based on params[:conversation]" do
       @conversation.save
       params = { conversation: @conversation.number }
-      assert_equal @conversation.id, Concierge.new(@account, params).find_conversation.id
+      assert_equal @conversation.id, Concierge.find_conversation(@account, params).id
     end
 
     it "should find a conversation based on params[:recipient]" do
       @conversation.save
       params = { recipient: @conversation.mailbox_email.to_s }
-      assert_equal @conversation.id, Concierge.new(@account, params).find_conversation.id
+      assert_equal @conversation.id, Concierge.find_conversation(@account, params).id
     end
 
     it "should prefer params[:conversation] over params[:recipient]" do
@@ -27,14 +27,14 @@ describe Concierge do
         conversation: @conversation.number,
         recipient:    @conversation_2.mailbox_email.to_s
       }
-      assert_equal @conversation.id, Concierge.new(@account, params).find_conversation.id
+      assert_equal @conversation.id, Concierge.find_conversation(@account, params).id
     end
 
     it "should create a new conversation when one cannot be found" do
       @conversation.save
       params = { conversation: 10000000 }
       assert_difference "@account.conversations.count" do
-        Concierge.new(@account, params).find_conversation
+        Concierge.find_conversation(@account, params)
       end
     end
 
@@ -43,7 +43,7 @@ describe Concierge do
       params = { recipient: @conversation.mailbox_email.to_s }
       @conversation.delete
       assert_difference "@account.conversations.count" do
-        Concierge.new(@account, params).find_conversation
+        Concierge.find_conversation(@account, params)
       end
     end
 
@@ -51,7 +51,7 @@ describe Concierge do
       @conversation.save
       params = { conversation: @conversation.number }
       assert_no_difference "@account.conversations.count" do
-        Concierge.new(@account, params).find_conversation
+        Concierge.find_conversation(@account, params)
       end
     end
   end


### PR DESCRIPTION
If we are not going to use Concierge as a class, it should become a module. 
Now the syntax is shorter and more clear