### PR TITLE
Skip time-out flash

### DIFF
--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,6 +1,7 @@
 <% unless flash.empty? %>
   <div id="flash-messages">
     <% flash.each do |key, value| %>
+      <% next if key == "timedout" %>
       <div class="<%= flash_class(key) %> alert-dismissible">
         <div class="container">
           <span class="<%= flash_icon_class(key) %>"></span>


### PR DESCRIPTION
@vanstee This should fix the extra flash message containing true after your session has expired. I'm unable to test as I have no expired sessions. Any chance you know a quick solution to test it anyway?
