### PR TITLE
Force unix style line endings for code checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# From: https://help.github.com/articles/dealing-with-line-endings/#platform-windows
+# Git will always convert line endings to LF on checkout. We need this setting to make sure the code is checkout out with unix style line endings
+# This is because the vm has problems executing scripts with windows style line endings.
+text eol=lf


### PR DESCRIPTION
Windows style line endings cause issues with the virtual box when the code is checked out with windows style line endings, which is the recommended setting for git on windows.

The vagrant vm cannot handle these line endings in scripts, and so the code must be checked out with unix style line endings.

This setting in the gitattributes file will make sure code is checked out correctly. For more information, see https://help.github.com/articles/dealing-with-line-endings/#platform-windows.

Here is the difference in output before and after adding this file from vagrant up: https://gist.github.com/surajreddy/a8023f91ea64b5d20a7b
