### PR TITLE
#813: Alternate fix for css issue with subscribed text by increasing column size for medium viewport

### DIFF
--- a/app/assets/stylesheets/modules/panel.css.scss
+++ b/app/assets/stylesheets/modules/panel.css.scss
@@ -19,7 +19,6 @@
   .plan-subscribed {
     color: $brand-success;
     height: 36px;
-    padding-top: 7px;
 
     &:hover {
       text-decoration: none;

--- a/app/views/accounts/_billing.html.erb
+++ b/app/views/accounts/_billing.html.erb
@@ -20,7 +20,7 @@
     <div class="form-group">
       <div class="row">
         <% BillingPlan.options.each do |plan| %>
-          <div class="col-xs-12 col-sm-6 col-md-3">
+          <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
             <div class="panel panel-default text-center">
               <h4 class="text-capitalize">
                 <%= plan.name %>


### PR DESCRIPTION
The subscribed text overflows the box in the medium view resolution (768 ~ 1200), which was causing the issue. I also removed the top padding on the text because this makes it more aligned with the other text.

The text looked fine <768 and >1200, so I left those columns as is (if the resolution is more than 1200, the boxes use the same width)

An alternate solution if you'd still like 4 boxes on the same line is to use a padding of -22px on the text and checkbox div when the resolution is between 768 and 1200.
