### PR TITLE
Bounty #813: Fixed css issues with subscribed text on the billing page

### DIFF
--- a/app/assets/stylesheets/modules/panel.css.scss
+++ b/app/assets/stylesheets/modules/panel.css.scss
@@ -19,7 +19,7 @@
   .plan-subscribed {
     color: $brand-success;
     height: 36px;
-    padding-top: 7px;
+    padding: 0px;
 
     &:hover {
       text-decoration: none;
@@ -29,7 +29,6 @@
     .geomicon-check {
       font-size: 20px;
       display: inline-block;
-      padding-right: 2px;
       top: 2px;
     }
 

--- a/app/views/accounts/_billing.html.erb
+++ b/app/views/accounts/_billing.html.erb
@@ -36,7 +36,7 @@
                 <% end %>
               </p>
 
-              <button class="btn btn-default<% if plan == @account.billing_plan %> plan-subscribed btn-link<% end %>"
+              <button class="btn btn-default<% if plan == @account.billing_plan %> btn-link plan-subscribed<% end %>"
               data-plan-slug="<%= plan.slug %>"
               data-plan-name="<%= plan.name %>"
               data-plan-amount="<%= plan.formatted_price %>"


### PR DESCRIPTION
- Removing the padding on the subscribed box centers it better on the medium viewscale resolution. 
- I removed the padding after the checkmark beside subscribed because it looks better visually this way.
- I moved the plan-subscribed class so the padding settings override the btn classes.
