### PR TITLE
Fixed typo on new account page

### DIFF
--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -19,7 +19,7 @@
         <div class="col-xs-12 col-md-6">
 
           <div class="form-group">
-            <%= f.label :name, 'Accout name', class: 'control-label' %>
+            <%= f.label :name, 'Account name', class: 'control-label' %>
             <%= f.text_field :name, autofocus: true, class: 'form-control', required: true, autocomplete: :off %>
           </div>
 


### PR DESCRIPTION
Changed the label from "Accout name" to "Account name"