### PR TITLE
Assembly Bounty #910

### DIFF
--- a/app/assets/javascripts/components/response.js.jsx
+++ b/app/assets/javascripts/components/response.js.jsx
@@ -3,6 +3,14 @@
 var Response = React.createClass({
   componentDidMount: function() {
     this.initMediumEditor();
+    var savedResponse = sessionStorage.getItem(this.props.conversation.id)
+    $('.medium-editor').html(savedResponse)
+    $('.medium-editor').removeClass('medium-editor-placeholder');
+  },
+
+  componentWillUnmount: function() {
+    var content = $('.medium-editor').html()
+    sessionStorage.setItem(this.props.conversation.id, content)
   },
 
   initMediumEditor: function() {
@@ -76,6 +84,7 @@ var Response = React.createClass({
 
   clearResponse: function() {
     $('.medium-editor').html('');
+    sessionStorage.setItem(this.props.conversation.id, null);
   },
 
   useCannedResponseHandler: function(cannedResponse) {
@@ -106,7 +115,7 @@ var Response = React.createClass({
   render: function() {
     return (
       <form className="form">
-        <div className="form-control form-control-invisible medium-editor" data-placeholder="Click and write your response..." onKeyDown={this.metaSend} onKeyPress={this.ctrlSend}></div>
+        <div id={this.props.conversation.id} className="form-control form-control-invisible medium-editor" data-placeholder="Click and write your response..." onKeyDown={this.metaSend} onKeyPress={this.ctrlSend}></div>
 
         <div className="form-actions">
           <div className="pull-right">

--- a/app/assets/javascripts/components/response.js.jsx
+++ b/app/assets/javascripts/components/response.js.jsx
@@ -5,12 +5,18 @@ var Response = React.createClass({
     this.initMediumEditor();
     var savedResponse = sessionStorage.getItem(this.props.conversation.id)
     $('.medium-editor').html(savedResponse)
-    $('.medium-editor').removeClass('medium-editor-placeholder');
+    if (savedResponse != null) {
+      $('.medium-editor').removeClass('medium-editor-placeholder');
+    }
   },
 
   componentWillUnmount: function() {
     var content = $('.medium-editor').html()
-    sessionStorage.setItem(this.props.conversation.id, content)
+    if ($('.medium-editor').text()) {
+      sessionStorage.setItem(this.props.conversation.id, content)
+    } else {
+      sessionStorage.removeItem(this.props.conversation.id)
+    }
   },
 
   initMediumEditor: function() {
@@ -84,7 +90,7 @@ var Response = React.createClass({
 
   clearResponse: function() {
     $('.medium-editor').html('');
-    sessionStorage.setItem(this.props.conversation.id, null);
+    sessionStorage.removeItem(this.props.conversation.id);
   },
 
   useCannedResponseHandler: function(cannedResponse) {


### PR DESCRIPTION
Note:
React-rails breaks when upgrading to React 0.13, which means we can't use React.findDOMNode.

MediumEditor does not respect disablePlaceholders so we remove the class manually.