### PR TITLE
Bugfix: Update doorkeeper to use before_action

### DIFF
--- a/app/controllers/api/attachments_controller.rb
+++ b/app/controllers/api/attachments_controller.rb
@@ -1,5 +1,5 @@
 class Api::AttachmentsController < ApiController
-  doorkeeper_for :all, except: [ :create ]
+  before_action :doorkeeper_authorize!
 
   def index
     message = Message.includes(:attachments).find(params[:message_id])


### PR DESCRIPTION
Details of bug at https://github.com/asm-helpful/helpful-web/issues/344

The existing code uses    `doorkeeper_for :all, except: [ :create ]`

This will cause the following error

```
 [1563] - Worker 0 (pid: 1571) booted, phase: 0
12:53:24 worker.1 | `doorkeeper_for` no longer available
12:53:24 worker.1 |
12:53:24 worker.1 | Starting in version 2.0.0 of doorkeeper gem, `doorkeeper_for` is no longer
12:53:24 worker.1 | available. Please change `doorkeeper_for` calls in your application with:
12:53:24 worker.1 |
12:53:24 worker.1 |   before_action :doorkeeper_authorize!
12:53:24 worker.1 |
12:53:24 worker.1 | For more information check the README:
12:53:24 worker.1 | https://github.com/doorkeeper-gem/doorkeeper#protecting-resources-with-oauth-aka-your-api-endpoint
12:53:24 worker.1 |
12:53:24 worker.1 | exited with code 1
```

Further details here
https://github.com/doorkeeper-gem/doorkeeper#protecting-resources-with-oauth-aka-your-api-endpoint
